### PR TITLE
Fix escaped backslash in a string

### DIFF
--- a/syntax/happy.vim
+++ b/syntax/happy.vim
@@ -10,7 +10,7 @@ syn region happyHsSnippet matchgroup=happyDelim start="{%\?" end="}" contains=@H
 syn region happyHsBraces matchgroup=hsDelimiter start="{\ze[^-]" end="}" contains=@Haskell,happyHsBrace contained
 syn region happyHsPragma start="{-#" end="#-}" contained
 syn region happyMComment start="{-\ze[^#]" end="-}"
-syn region happyString start="\k\@<!\z(['\"]\)" end="\z1" skip="\\\z1"
+syn region happyString start="\k\@<!\z(['\"]\)" end="\z1" skip="\(\\\)\@<!\\\z1"
 syn match happyNumber "\<\d\+\>"
 syn match happyPrimeErr "\k\zs'\+"
 syn match happySplice "\\\@<!\$\([\$>]\|\d\+\)" contained


### PR DESCRIPTION
This PR fixes the highlighting of `'\\'`, which originally was treated as an escaped `'` (quote):
![image](https://user-images.githubusercontent.com/30177086/111915304-e5f2b180-8a4b-11eb-9c21-db3120cf9f4f.png)
After this fix:
![image](https://user-images.githubusercontent.com/30177086/111915322-06227080-8a4c-11eb-91df-9ff2ca6cbe7d.png)
